### PR TITLE
make pluckAttributeWithStringFormat compatible with a Backbone Model

### DIFF
--- a/specs/Tools_spec.js
+++ b/specs/Tools_spec.js
@@ -69,13 +69,6 @@ define(['Graft'], function (Graft) {
         chai.expect(Graft.Tools.pluckAttributeWithStringFormat(x, 'methodName()', true)).to.equal(x.methodName);
       });
     });
-    
-    describe('#pluckAttribute', function () {
-      it('plucks a simple attribute', function () {
-        var x = {a: 100};
-        chai.expect(Graft.Tools.pluckAttribute(x, 'a')).to.equal(x.a);
-      });
-    });
 
     describe('#getAttributeFromModelWithStringFormat', function () {
       beforeEach(function () {

--- a/specs/Tools_spec.js
+++ b/specs/Tools_spec.js
@@ -69,5 +69,41 @@ define(['Graft'], function (Graft) {
         chai.expect(Graft.Tools.pluckAttributeWithStringFormat(x, 'methodName()', true)).to.equal(x.methodName);
       });
     });
+    
+    describe('#pluckAttribute', function () {
+      it('plucks a simple attribute', function () {
+        var x = {a: 100};
+        chai.expect(Graft.Tools.pluckAttribute(x, 'a')).to.equal(x.a);
+      });
+    });
+
+    describe('#getAttributeFromModelWithStringFormat', function () {
+      beforeEach(function () {
+        this.model = new Backbone.Model({a: 100});
+        this.model['plucked'] = 5;
+        this.model['methodName'] = function () {
+          return 2;
+        };
+      });
+      afterEach(function () {
+        delete this.model;
+      });
+
+      it("returns backbone model's attribute with get", function() {
+        chai.expect(Graft.Tools.getAttributeFromModelWithStringFormat(this.model, 'a')).to.equal(this.model.get('a'));
+      });
+      it("calls function and returns value on backbone model", function() {
+        chai.expect(Graft.Tools.getAttributeFromModelWithStringFormat(this.model, 'methodName()')).to.equal(2);
+      });
+      it("returns method without calling it when dontCallFunctions option is set", function() {
+        var options = { dontCallFunctions: true };
+        chai.expect(Graft.Tools.getAttributeFromModelWithStringFormat(this.model, 'methodName()', options)).to.equal(this.model.methodName);
+      });
+      it("plucks the attribute from the model when pluckAttribute option is set", function() {
+        var options = { pluckAttribute: true }
+        chai.expect(Graft.Tools.getAttributeFromModelWithStringFormat(this.model, 'plucked', options)).to.equal(5);
+      });
+    });
+
   });
 });

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -110,18 +110,14 @@
       });
     },
 
-    pluckAttribute: function (item, string) {
-      return item[string];
-    },
-
     pluckAttributeWithStringFormat: function (item, string, dontCallFunctions) {
       var parsed = Tools.parseAttributeFromString(string);
       
       if (parsed.isFunction && !dontCallFunctions) {
-        return this.pluckAttribute(item, parsed.name)();
+        return item[parsed.name]();
       }
 
-      return this.pluckAttribute(item, parsed.name);
+      return item[parsed.name];
     },
 
     getAttributeFromModelWithStringFormat: function (model, string, options) {
@@ -129,7 +125,7 @@
       var parsed = Tools.parseAttributeFromString(string);
 
       if (options.pluckAttribute) {
-        return this.pluckAttribute(model, parsed.name);
+        return model[parsed.name];
       } else if (!parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -104,9 +104,7 @@
       options = options || {};
       var parsed = Tools.parseAttributeFromString(string);
 
-      if (options.pluckAttribute) {
-        return model[parsed.name];
-      } else if (!parsed.isFunction && !options.dontCallFunctions) {
+      if (!options.pluckAttribute && !parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }
 

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -110,15 +110,31 @@
       });
     },
 
+    pluckAttribute: function (item, string) {
+      return item[string];
+    },
+
     pluckAttributeWithStringFormat: function (item, string, dontCallFunctions) {
       var parsed = Tools.parseAttributeFromString(string);
+      
       if (parsed.isFunction && !dontCallFunctions) {
-        return item[parsed.name]();
-      } else if (item instanceof Backbone.Model) {
-        return item.get(string);
-      } else {
-        return item[parsed.name];
+        return this.pluckAttribute(item, parsed.name)();
       }
+
+      return this.pluckAttribute(item, parsed.name);
+    },
+
+    getAttributeFromModelWithStringFormat: function (model, string, options) {
+      options = options || {};
+      var parsed = Tools.parseAttributeFromString(string);
+
+      if (options.pluckAttribute) {
+        return this.pluckAttribute(model, parsed.name);
+      } else if (model instanceof Backbone.Model && !parsed.isFunction && !options.dontCallFunctions) {
+        return model.get(parsed.name);
+      }
+
+      return this.pluckAttributeWithStringFormat(model, string, options.dontCallFunctions);
     },
 
     pluckAttributesWithStringFormats: function (item, string) {

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -110,7 +110,7 @@
 
       if (options.pluckAttribute) {
         return this.pluckAttribute(model, parsed.name);
-      } else if (model instanceof Backbone.Model && !parsed.isFunction && !options.dontCallFunctions) {
+      } else if (!parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }
 

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -124,9 +124,7 @@
       options = options || {};
       var parsed = Tools.parseAttributeFromString(string);
 
-      if (options.pluckAttribute) {
-        return model[parsed.name];
-      } else if (!parsed.isFunction && !options.dontCallFunctions) {
+      if (!options.pluckAttribute && !parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }
 

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -90,18 +90,14 @@
       });
     },
 
-    pluckAttribute: function (item, string) {
-      return item[string];
-    },
-
     pluckAttributeWithStringFormat: function (item, string, dontCallFunctions) {
       var parsed = Tools.parseAttributeFromString(string);
       
       if (parsed.isFunction && !dontCallFunctions) {
-        return this.pluckAttribute(item, parsed.name)();
+        return item[parsed.name]();
       }
 
-      return this.pluckAttribute(item, parsed.name);
+      return item[parsed.name];
     },
 
     getAttributeFromModelWithStringFormat: function (model, string, options) {
@@ -109,7 +105,7 @@
       var parsed = Tools.parseAttributeFromString(string);
 
       if (options.pluckAttribute) {
-        return this.pluckAttribute(model, parsed.name);
+        return model[parsed.name];
       } else if (!parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -94,6 +94,8 @@
       var parsed = Tools.parseAttributeFromString(string);
       if (parsed.isFunction && !dontCallFunctions) {
         return item[parsed.name]();
+      } else if (item instanceof Backbone.Model) {
+        return item.get(string);
       } else {
         return item[parsed.name];
       }

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -241,7 +241,8 @@
       Backbone.View.apply(this , arguments);
     },
 
-    initialize: function () {
+    initialize: function (o) {
+      this.options = _.extend({}, this.options, o || {});
       this._boundRelayEvents = {};
       this._subViews = {};
       this._setup();

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -130,7 +130,7 @@
 
       if (options.pluckAttribute) {
         return this.pluckAttribute(model, parsed.name);
-      } else if (model instanceof Backbone.Model && !parsed.isFunction && !options.dontCallFunctions) {
+      } else if (!parsed.isFunction && !options.dontCallFunctions) {
         return model.get(parsed.name);
       }
 

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -114,6 +114,8 @@
       var parsed = Tools.parseAttributeFromString(string);
       if (parsed.isFunction && !dontCallFunctions) {
         return item[parsed.name]();
+      } else if (item instanceof Backbone.Model) {
+        return item.get(string);
       } else {
         return item[parsed.name];
       }

--- a/src/Graft.js
+++ b/src/Graft.js
@@ -90,15 +90,31 @@
       });
     },
 
+    pluckAttribute: function (item, string) {
+      return item[string];
+    },
+
     pluckAttributeWithStringFormat: function (item, string, dontCallFunctions) {
       var parsed = Tools.parseAttributeFromString(string);
+      
       if (parsed.isFunction && !dontCallFunctions) {
-        return item[parsed.name]();
-      } else if (item instanceof Backbone.Model) {
-        return item.get(string);
-      } else {
-        return item[parsed.name];
+        return this.pluckAttribute(item, parsed.name)();
       }
+
+      return this.pluckAttribute(item, parsed.name);
+    },
+
+    getAttributeFromModelWithStringFormat: function (model, string, options) {
+      options = options || {};
+      var parsed = Tools.parseAttributeFromString(string);
+
+      if (options.pluckAttribute) {
+        return this.pluckAttribute(model, parsed.name);
+      } else if (model instanceof Backbone.Model && !parsed.isFunction && !options.dontCallFunctions) {
+        return model.get(parsed.name);
+      }
+
+      return this.pluckAttributeWithStringFormat(model, string, options.dontCallFunctions);
     },
 
     pluckAttributesWithStringFormats: function (item, string) {


### PR DESCRIPTION
pluckAttributeWithStringFormat should check if the item is a model. If it is, return the models attribute value
